### PR TITLE
Update documentation with GitHub Actions info and test accounts

### DIFF
--- a/docs/dokumentacja_instalacyjno-konfiguracyjna_systemu/dokumentacja_instalacyjno-konfiguracyjna_systemu/dokumentacja_instalacyjno-konfiguracyjna_systemu.tex
+++ b/docs/dokumentacja_instalacyjno-konfiguracyjna_systemu/dokumentacja_instalacyjno-konfiguracyjna_systemu/dokumentacja_instalacyjno-konfiguracyjna_systemu.tex
@@ -152,6 +152,7 @@ cd WasteFree
 
 \section{Struktura repozytorium (skrót)}
 \begin{itemize}
+  \item `.github/` – konfiguracja GitHub Actions (CI/CD) oraz definicje właścicieli kodu.
   \item `API/` – backend (.NET 9), główny projekt `WasteFree.Api`.
   \item `UI/` – frontend Angular 17, pliki konfiguracyjne npm/Angular CLI.
   \item `docker-compose.yml` – definicje usług (API + opcjonalne usługi).
@@ -245,6 +246,8 @@ test4 & Kwakwa5! \\ \hline
 test5 & Kwakwa5! \\ \hline
 garbageadmin1 & Kwakwa5! \\ \hline
 garbageadmin2 & Kwakwa5! \\ \hline
+admin1 & Kwakwa5! \\ \hline
+admin2 & Kwakwa5! \\ \hline
 \end{tabular}
 \caption{Dane logowania do kont testowych}
 \end{table}


### PR DESCRIPTION
Added `.github/` directory description to the repository structure section to clarify CI/CD configuration location. Included two new admin test accounts in the test login data table.